### PR TITLE
Add OctoAcme project management docs README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,22 @@
+# OctoAcme Project Management Docs
+
+## Overview
+
+OctoAcme uses a lightweight but structured project management model that moves work through clear stages: initiation, planning, execution, release, and retrospective improvement. New work begins with a one-pager that captures the problem, goals, success metrics, stakeholders, timeline, risks, and resource needs. An initiative moves forward only after stakeholders align on priority, the outcome is measurable, and the team has the capacity to deliver.
+
+Once approved, the work is translated into a prioritized backlog of shippable increments with clear acceptance criteria, estimates, milestones, dependencies, and a documented Definition of Done. Delivery is owned jointly by cross-functional roles: the Project Manager coordinates schedule, risks, and communication; the Product Manager defines outcomes and prioritization; developers contribute implementation, estimation, documentation, testing, and technical risk identification; and QA supports feature validation and release confidence.
+
+Execution is managed through predictable team rhythms and visible workflow states. Daily standups surface progress and blockers, weekly syncs track delivery and risk, and milestone-based stakeholder updates keep broader groups aligned. OctoAcme emphasizes a single source of truth for status, uses defined escalation paths for blockers and incidents, and treats communication as part of delivery rather than a separate reporting activity.
+
+Quality assurance is built into the process from planning through release. Work is expected to meet acceptance criteria before entering an iteration, move through review and QA stages on the project board, and pass automated testing, linting, CI checks, security scans, and smoke tests before release when applicable. Releases also require rollback planning and post-deploy verification, and retrospectives after sprints, milestones, releases, or incidents turn lessons learned into small, owned improvement actions that are tracked to completion.
+
+## Documentation Links
+
+- [Project Management Overview](./octoacme-project-management-overview.md)
+- [Project Initiation Guide](./octoacme-project-initiation.md)
+- [Project Planning](./octoacme-project-planning.md)
+- [Execution & Tracking](./octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](./octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](./octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](./octoacme-retrospective-and-continuous-improvement.md)
+- [Personas & Roles](./octoacme-roles-and-personas.md)


### PR DESCRIPTION
## Summary
- add docs/README.md as the central landing page for OctoAcme project management documentation
- include a brief overview of workflows, roles, communication, and quality assurance
- add direct links to every process document in the docs folder

Closes #2